### PR TITLE
Fix depacketization for NatNet 3.0 syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# optirack_bridge
+# optitrack_bridge
 
 ROS node optitrack_bridge_node, listen to pose multicasted via UDP by optitrack system, and republish it as ROS messages.
 
-- parameter `address`, mutlicast address for optitrack system, default to `239.255.42.99`
+- parameter `address`, multicast address for optitrack system, default to `239.255.42.99`
 - parameter `port`, multicast address for optitrack system, default to `1511`
 - parameter `body_name`, name of rigid body published by optitrack, default to `base_link`
 - parameter `body_frame_id`, frame_id of rigid body published to ROS, default to the name from optitrack

--- a/src/optitrack_bridge.cpp
+++ b/src/optitrack_bridge.cpp
@@ -95,8 +95,8 @@ struct RigidBody
 	float x, y, z;
 	float qx, qy, qz, qw;
 
-	int32_t num_markers;
-	Point markers[0];
+//	int32_t num_markers;
+//	Point markers[0];
 } __attribute__((packed));
 
 struct LabelledMarker
@@ -262,19 +262,20 @@ void OptitrackBridge::HandlePacket(const void* buffer, int len)
 
 			const char* rigid_body_name = marker_ids[i];
 
-			if (rigid_body->num_markers > 100 || rigid_body->num_markers < 0)
+			/*if (rigid_body->num_markers > 100 || rigid_body->num_markers < 0)
 			{
 			     ROS_ERROR("Bad number of markers, probably a parse error");
+                 ROS_ERROR_STREAM(rigid_body_name << " " << rigid_body->num_markers);
 			     return;
-			}
+			}*/
 
 			Skip(buf_ptr, sizeof(RigidBody));
 			// skip marker positions
-			Skip(buf_ptr, sizeof(Point) * rigid_body->num_markers);
+			//Skip(buf_ptr, sizeof(Point) * rigid_body->num_markers);
 			// skip marker ids
-			Skip(buf_ptr, sizeof(int32_t) * rigid_body->num_markers);
+			//Skip(buf_ptr, sizeof(int32_t) * rigid_body->num_markers);
 			// skip marker sizes
-			Skip(buf_ptr, sizeof(float) * rigid_body->num_markers);
+			//Skip(buf_ptr, sizeof(float) * rigid_body->num_markers);
 
 			float mean_marker_error = Read<float>(buf_ptr);
 			int validity = Read<int16_t>(buf_ptr);
@@ -302,10 +303,10 @@ void OptitrackBridge::HandlePacket(const void* buffer, int len)
 				valid = true;
 			}
 
-//			ROS_INFO("Pose %s, (%f,%f,%f), (%f,%f,%f,%f)",
-//					rigid_body_name,
-//					rigid_body->x, rigid_body->y, rigid_body->z,
-//					rigid_body->qx, rigid_body->qy, rigid_body->qz,rigid_body->qw);
+			ROS_INFO("Pose %s, (%f,%f,%f), (%f,%f,%f,%f)",
+					rigid_body_name,
+					rigid_body->x, rigid_body->y, rigid_body->z,
+					rigid_body->qx, rigid_body->qy, rigid_body->qz,rigid_body->qw);
 		}
 
 		// skip skeletons


### PR DESCRIPTION
This copes with NatNet 3.0's changes to the bit-stream syntax.  Information about rigid body marker positions etc. is now included in "data descriptions" packets (with message id 5) instead of "frame of mocap data" packets (with message id 7).  optitrack_bridge just skips over all this rigid body marker data anyway, so I commented out everything that cares about the individual rigid body markers and it seems to publish poses just fine.  